### PR TITLE
merge feature/root-parallel

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ Since MCTS is sometimes cited as an _embarassingly parallelisable_ algorithm, I 
 
 - [x] interfaces to define abstract MCTS implementations
 - [x] single-threaded MCTS
+- [x] concurrent multi-threaded MCTS (root-parallel model implemented)
 - [ ] optimization for general-case MCTS
 - [ ] basic documentation
-- [ ] concurrent multi-threaded MCTS
 - [ ] a _worker-based_ concurrency model
   - [ ] leaf parallelisation
   - [ ] root parallelisation

--- a/montecarlo/montecarlo.go
+++ b/montecarlo/montecarlo.go
@@ -1,6 +1,9 @@
 package montecarlo
 
-import "sync"
+import (
+	"fmt"
+	"sync"
+)
 
 // ActionSet is a map from string to action
 type ActionSet map[Key]Action
@@ -32,7 +35,7 @@ type State interface {
 	Policy() Policy
 }
 
-/*-------- TreeSearcher DEFAULT IMPLEMENTATION --------*/
+/*-------- MONTECARLO TREE SEARCH IMPLEMENTATIONS --------*/
 
 // MultiplayerMCTS encapsulates the information required for a basic MCTS
 // implementation, including: its search tree; and its policy for operating on
@@ -57,31 +60,11 @@ func NewMultiplayerMCTS(numPlayers uint, init State, actions map[Key]Action) (Mu
 func (mcts MultiplayerMCTS) Search(level int64, expl float64) (Key, *Action, error) {
 	for i := int64(0); i < level; i++ {
 		root := mcts.tree.Root()
-		node := root.Policy().Select(&root, expl)
+		node := root.Policy().Select(root, expl)
 		node.Policy().Backpropagate(node, node.Policy().Simulate(node))
 		//log.Infof("finished %vth simulation", i)
 	}
-	/*
-		// debugging output
-		for k, c := range mcts.tree.Root().children {
-			fmt.Printf("{%v: %v/%v | current player: %v | UCB %v}\n",
-				k,
-				c.ScoreVector(),
-				c.Visits(),
-				c.Player(),
-				c.UpperConfidenceBound(expl, c.Player()),
-			)
-			for k2, c2 := range c.children {
-				fmt.Printf("\t{ %v: %v/%v | current player: %v | UCB %v}\n",
-					k2,
-					c2.ScoreVector(),
-					c2.Visits(),
-					c2.Player(),
-					c2.UpperConfidenceBound(expl, c2.Player()),
-				)
-			}
-		}
-	*/
+	//mcts.printDebugOutput(expl)
 	// maximise exploitation over exploration by setting the exploration parameter
 	// to 0
 	key, _ := mcts.tree.root.selectBestChild(0)
@@ -98,28 +81,61 @@ func (mcts MultiplayerMCTS) RootParallelSearch(numThreads int, level int64, expl
 	trees := make(chan *Tree, numThreads)
 	var counter sync.WaitGroup
 	counter.Add(numThreads)
+	// start processing a copy of the root on each thread
 	for threadno := 0; threadno < numThreads; threadno++ {
-		go func() {
-			defer counter.Done()
-			// create a separate copy of the initial tree for this thread
-			tree := mcts.tree.Copy()
+		// create a separate copy of the initial tree for each thread
+		//tree, _ := NewTree(mcts.tree.Root().NumPlayers(), mcts.tree.Root().State.Copy(), mcts.tree.Root().State.LegalActions())
+		tree := mcts.tree.Copy()
+		fmt.Printf("created tree copy %p \n", tree)
+		go func(threadno int, tree *Tree) {
+			fmt.Printf("starting MCTS for tree %p on thread %v\n", tree, threadno)
 			for i := int64(0); i < level; i++ {
 				root := tree.Root()
-				node := root.Policy().Select(&root, expl)
+				node := root.Policy().Select(root, expl)
 				node.Policy().Backpropagate(node, node.Policy().Simulate(node))
 			}
+			fmt.Printf("finished MCTS for thread %v\n", threadno)
+			// this tree will get merged with the base tree synchronously
 			trees <- tree
-		}()
+		}(threadno, tree)
 	}
-	// merge all created trees
 	go func() {
-		for t := range trees {
-			mcts.tree.Merge(*t)
-		}
+		// close the channel when all trees are processed
+		counter.Wait()
+		close(trees)
 	}()
-	// wait for all searches to finish
-	counter.Wait()
+	// merge all created trees as they arrive in the channel (synchronously)
+	fmt.Printf("waiting for trees to process\n")
+	for t := range trees {
+		fmt.Printf("got finished tree to process\n")
+		// TODO: investigate asynchronous map read/write implementations
+		// TODO: may provide benefit for sufficiently large trees
+		mcts.tree.Merge(t)
+		counter.Done()
+	}
 	key, _ := mcts.tree.root.selectBestChild(0)
 	action := mcts.tree.PossibleActions()[key]
 	return key, &action, nil
+}
+
+func (mcts MultiplayerMCTS) printDebugOutput(expl float64) {
+	// debugging output
+	for k, c := range mcts.tree.Root().children {
+		fmt.Printf("{%v: %v/%v | current player: %v | UCB %v}\n",
+			k,
+			c.ScoreVector(),
+			c.Visits(),
+			c.Player(),
+			c.UpperConfidenceBound(expl, c.Player()),
+		)
+		for k2, c2 := range c.children {
+			fmt.Printf("\t{ %v: %v/%v | current player: %v | UCB %v}\n",
+				k2,
+				c2.ScoreVector(),
+				c2.Visits(),
+				c2.Player(),
+				c2.UpperConfidenceBound(expl, c2.Player()),
+			)
+		}
+	}
 }

--- a/montecarlo/montecarlo.go
+++ b/montecarlo/montecarlo.go
@@ -86,15 +86,12 @@ func (mcts MultiplayerMCTS) RootParallelSearch(numThreads int, level int64, expl
 		// create a separate copy of the initial tree for each thread
 		//tree, _ := NewTree(mcts.tree.Root().NumPlayers(), mcts.tree.Root().State.Copy(), mcts.tree.Root().State.LegalActions())
 		tree := mcts.tree.Copy()
-		fmt.Printf("created tree copy %p \n", tree)
 		go func(threadno int, tree *Tree) {
-			fmt.Printf("starting MCTS for tree %p on thread %v\n", tree, threadno)
 			for i := int64(0); i < level; i++ {
 				root := tree.Root()
 				node := root.Policy().Select(root, expl)
 				node.Policy().Backpropagate(node, node.Policy().Simulate(node))
 			}
-			fmt.Printf("finished MCTS for thread %v\n", threadno)
 			// this tree will get merged with the base tree synchronously
 			trees <- tree
 		}(threadno, tree)
@@ -105,9 +102,7 @@ func (mcts MultiplayerMCTS) RootParallelSearch(numThreads int, level int64, expl
 		close(trees)
 	}()
 	// merge all created trees as they arrive in the channel (synchronously)
-	fmt.Printf("waiting for trees to process\n")
 	for t := range trees {
-		fmt.Printf("got finished tree to process\n")
 		// TODO: investigate asynchronous map read/write implementations
 		// TODO: may provide benefit for sufficiently large trees
 		mcts.tree.Merge(t)

--- a/montecarlo/node.go
+++ b/montecarlo/node.go
@@ -72,53 +72,62 @@ func (node Node) Copy() *Node {
 // and Visit values are added.
 func (node *Node) Merge(other Node) error {
 	//TODO make a version of Merge that does not create side-effects
-	players := node.NumPlayers()
-	// check for incompatibility
-	if other.NumPlayers() != players {
-		return MergeDifferingPlayerCount{
-			players,
-			other.NumPlayers(),
-		}
+	// check for any errors that mean the node cannot be merged
+	err := node.mergeGetErrors(other)
+	if err != nil {
+		return err
 	}
-	if node.State != nil && other.State != nil && node.Player() != other.Player() {
-		return MergePlayerIndexMismatch{
-			node.Player(),
-			other.Player(),
-		}
-	}
-	if node.State != other.State {
-		return MergeStateMismatch{
-			node.State,
-			other.State,
-		}
-	}
-	// add the other node's values to this node
-	for i := uint(0); i < players; i++ {
+	// add/merge node values
+	for i := uint(0); i < node.NumPlayers(); i++ {
 		node.score[i] += other.score[i]
 	}
 	node.visits += other.Visits()
-	if other.State != nil {
+	if node.State == nil && other.State != nil {
 		node.State = other.State.Copy()
 	}
-	// add children
+	// Add child nodes from other to this node.
+	// If this node doesn't contain a child from other, it is copied.
+	// All nodes in common are recursively merged (depth-first).
 	for k, otherChild := range other.children {
 		if otherChild == nil {
 			continue
 		}
 		if _, ok := node.children[k]; !ok {
 			// if a child with that key does not exist on this node, make it
-			n, err := NewNode(players)
-			if err != nil {
-				// this really shouldn't happen
-				return err
-			}
-			node.SetChild(k, &n)
-		}
-		// recurse, merging children
-		if otherChild != nil {
+			otherCopy := otherChild.Copy()
+			// copies work from the node down (parent is culled out)
+			node.SetChild(k, otherCopy)
+		} else {
 			node.GetChild(k).Merge(*otherChild)
 		}
 	}
+	return nil
+}
+
+// Generates any errors associated with merging with the node "other".
+func (node *Node) mergeGetErrors(other Node) error {
+	// player count needs to be consistent
+	if other.NumPlayers() != node.NumPlayers() {
+		return MergeDifferingPlayerCount{
+			node.NumPlayers(),
+			other.NumPlayers(),
+		}
+	}
+	// player at this state needs to be consistent
+	if node.State != nil && other.State != nil && node.Player() != other.Player() {
+		return MergePlayerIndexMismatch{
+			node.Player(),
+			other.Player(),
+		}
+	}
+	// state needs to be consistent (if the first two errors do not
+	// adequately capture this already)
+	//if node.State != other.State {
+	//	return MergeStateMismatch{
+	//		node.State,
+	//		other.State,
+	//	}
+	//}
 	return nil
 }
 

--- a/montecarlo/node_test.go
+++ b/montecarlo/node_test.go
@@ -304,11 +304,17 @@ func TestNodeCopy(t *testing.T) {
 		assert.True(t, ok)
 		assert.NotEqual(t, &c, cpyChild)
 		assert.Equal(t, c.State, cpyChild.State)
+		assert.Equal(t, c.Parent(), &nodeWithGrandchildren)
+		assert.Equal(t, cpyChild.Parent(), cpy)
 		for k2, c2 := range c.children {
-			cpyChild, ok := cpy.children[k].children[k2]
+			cpyGrandchild, ok := cpy.children[k].children[k2]
 			assert.True(t, ok)
-			assert.NotEqual(t, &c2, cpyChild)
-			assert.Equal(t, c2.State, cpyChild.State)
+			assert.NotEqual(t, &c2, cpyGrandchild)
+			assert.Equal(t, c2.Parent(), c)
+			assert.Equal(t, cpyGrandchild.Parent(), cpyChild)
+			assert.Equal(t, c2.State, cpyGrandchild.State)
+			assert.Equal(t, c2.Parent().Parent(), &nodeWithGrandchildren)
+			assert.Equal(t, cpyGrandchild.Parent().Parent(), cpy)
 		}
 	}
 }
@@ -316,7 +322,7 @@ func TestNodeCopy(t *testing.T) {
 func TestNodeMergeWithSelf(t *testing.T) {
 	nodeTestSetup()
 	cpy := nodeWithGrandchildren.Copy()
-	err := nodeWithGrandchildren.Merge(*cpy)
+	err := nodeWithGrandchildren.Merge(cpy)
 	if err != nil {
 		assert.Fail(t, err.Error())
 	}
@@ -328,6 +334,12 @@ func TestNodeMergeWithSelf(t *testing.T) {
 		assert.Equal(t, v*2, s[i])
 	}
 	assert.Equal(t, len(cpy.children), len(nodeWithGrandchildren.children))
+	for k, c := range cpy.children {
+		assert.Equal(t, c.Parent(), cpy)
+		originalChild, ok := nodeWithGrandchildren.children[k]
+		assert.True(t, ok, "expected child nodes to be the same when merging with self")
+		assert.Equal(t, originalChild.Parent(), &nodeWithGrandchildren)
+	}
 }
 
 func TestNodeMergeDifferingPlayerCount(t *testing.T) {
@@ -336,7 +348,7 @@ func TestNodeMergeDifferingPlayerCount(t *testing.T) {
 	if err != nil {
 		assert.Fail(t, err.Error())
 	}
-	err = nodeWithGrandchildren.Merge(node)
+	err = nodeWithGrandchildren.Merge(&node)
 	assert.NotNil(t, err, "expected MergeDifferingPlayercount error when merging")
 	var ok bool
 	err, ok = err.(MergeDifferingPlayerCount)
@@ -355,7 +367,7 @@ func TestNodeMergePlayerIndexMismatch(t *testing.T) {
 	if err != nil {
 		assert.Fail(t, err.Error())
 	}
-	err = nodeWithGrandchildren.Merge(node)
+	err = nodeWithGrandchildren.Merge(&node)
 	assert.NotNil(t, err, "expected error when merging")
 	var ok bool
 	err, ok = err.(MergePlayerIndexMismatch)
@@ -409,4 +421,43 @@ func TestNodeWithStateIsExhausted(t *testing.T) {
 	assert.True(t, nodeWithChildren.IsExhausted())
 	nodeWithGrandchildren.State = simpleStateImplementation{}
 	assert.True(t, nodeWithGrandchildren.IsExhausted())
+}
+
+func TestNodeBackpropagateScoreCoherency(t *testing.T) {
+	nodeTestSetup()
+	for _, c := range nodeWithGrandchildren.children {
+		c.SetScore(0, float64(0))
+		assert.Equal(t, c.Score(0), float64(0))
+		for _, c2 := range c.children {
+			c2.SetScore(0, float64(0))
+			assert.Equal(t, c2.Score(0), float64(0))
+			c2.Policy().Backpropagate(c2, float64(1))
+			assert.Equal(t, c2.Score(0), float64(1))
+		}
+		assert.Equal(t, c.Score(0), float64(len(c.children)))
+	}
+	assert.True(t, nodeWithGrandchildren.Score(0) > 0, "expected root node score to be non-zero after backpropagating")
+}
+
+func TestNodeCopyBackpropagateScoreCoherency(t *testing.T) {
+	nodeTestSetup()
+	// set up the score in the tree how we'd like it
+	for _, c := range nodeWithGrandchildren.children {
+		c.SetScore(0, float64(0))
+		for _, c2 := range c.children {
+			c2.SetScore(0, float64(0))
+			c2.Policy().Backpropagate(c2, float64(1))
+		}
+	}
+	// create a copy
+	cpy := nodeWithGrandchildren.Copy()
+	// test values on the copy
+	for _, c := range cpy.children {
+		assert.Equal(t, c.Score(0), float64(10))
+		for _, c2 := range c.children {
+			assert.Equal(t, c2.Score(0), float64(1))
+		}
+	}
+	assert.True(t, cpy.Score(0) > 0, "expected copied root node score to be non-zero")
+	assert.Equal(t, cpy.Score(0), nodeWithGrandchildren.Score(0))
 }

--- a/montecarlo/tree.go
+++ b/montecarlo/tree.go
@@ -18,8 +18,8 @@ func NewTree(numPlayers uint, initialState State, possibleActions map[Key]Action
 }
 
 // Root returns the root montecarlo.Node of the tree.
-func (tree *Tree) Root() Node {
-	return tree.root
+func (tree *Tree) Root() *Node {
+	return &tree.root
 }
 
 // PossibleActions returns the set of possible actions defined in the
@@ -37,14 +37,14 @@ func (tree *Tree) Copy() *Tree {
 	root := tree.Root()
 	rootCpy := root.Copy()
 	// will not throw any error since we're already using a valid player count
-	cpy, _ := NewTree(root.NumPlayers(), root.State, actions)
+	cpy, _ := NewTree(root.NumPlayers(), rootCpy.State, actions)
 	cpy.root = *rootCpy
 	return &cpy
 }
 
 // Merge two trees together: add all nodes from other into this tree. If both
 // trees have the same node, then their Score and Visit values are added.
-func (tree *Tree) Merge(other Tree) error {
+func (tree *Tree) Merge(other *Tree) error {
 	root := tree.Root()
 	return root.Merge(other.Root())
 }


### PR DESCRIPTION
Have basic root-parallel model working. For the 3x3 tic-tac-toe test it runs slower than the single threaded model. This is due to the overhead of creating threads, and copying states between threads.

Further testing, benchmarking, and optimisation depends on more example games with deeper state spaces to justify the overhead cost.

Closes #3.